### PR TITLE
BREAKING CHANGE: Update Signing Message for Funding Lock and Commitment Lock (with Pending HTLC)

### DIFF
--- a/contracts/commitment-lock/src/main.rs
+++ b/contracts/commitment-lock/src/main.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 extern crate alloc;
 
-use ckb_hash::blake2b_256;
+use ckb_hash::{blake2b_256, new_blake2b};
 #[cfg(not(test))]
 use ckb_std::default_alloc;
 #[cfg(not(test))]
@@ -19,7 +19,7 @@ use ckb_std::{
     error::SysError,
     high_level::{
         exec_cell, load_cell, load_cell_capacity, load_cell_data, load_cell_lock, load_cell_type,
-        load_input_since, load_script, load_tx_hash, load_witness, QueryIter,
+        load_input_out_point, load_input_since, load_script, load_witness, QueryIter,
     },
     since::{EpochNumberWithFraction, LockValue, Since},
 };
@@ -193,7 +193,7 @@ fn auth() -> Result<(), Error> {
         ];
 
         exec_cell(&AUTH_CODE_HASH, ScriptHashType::Data1, &args).map_err(|_| Error::AuthError)?;
-        return Ok(());
+        Ok(())
     } else if unlock_type == 0xFE {
         // non-pending HTLC unlock process
 
@@ -250,7 +250,24 @@ fn auth() -> Result<(), Error> {
         }
 
         let raw_since_value = load_input_since(0, Source::GroupInput)?;
-        let message = load_tx_hash()?;
+        let message = {
+            let mut hasher = new_blake2b();
+            // hash all input out points
+            QueryIter::new(load_input_out_point, Source::Input).for_each(|out_point| {
+                hasher.update(out_point.as_slice());
+            });
+            // hash all outputs with data
+            QueryIter::new(load_cell, Source::Output)
+                .zip(QueryIter::new(load_cell_data, Source::Output))
+                .for_each(|(cell, data)| {
+                    hasher.update(cell.as_slice());
+                    hasher.update((data.len() as u32).to_le_bytes().as_ref());
+                    hasher.update(data.as_slice());
+                });
+            let mut hash_result = [0u8; 32];
+            hasher.finalize(&mut hash_result);
+            hash_result
+        };
         let mut signature = [0u8; 65];
         let mut pubkey_hash = [0u8; 20];
 

--- a/contracts/funding-lock/src/main.rs
+++ b/contracts/funding-lock/src/main.rs
@@ -4,7 +4,7 @@
 #[cfg(test)]
 extern crate alloc;
 
-use ckb_hash::new_blake2b;
+use ckb_hash::blake2b_256;
 #[cfg(not(test))]
 use ckb_std::default_alloc;
 #[cfg(not(test))]
@@ -17,10 +17,7 @@ use ckb_std::{
     ckb_constants::Source,
     ckb_types::{bytes::Bytes, core::ScriptHashType, prelude::*},
     error::SysError,
-    high_level::{
-        exec_cell, load_cell, load_cell_data, load_input_out_point, load_input_since, load_script,
-        load_witness, QueryIter,
-    },
+    high_level::{exec_cell, load_input_since, load_script, load_transaction, load_witness},
 };
 use hex::encode;
 
@@ -81,22 +78,12 @@ fn auth() -> Result<(), Error> {
     }
 
     let message = {
-        let mut hasher = new_blake2b();
-        // hash all input out points
-        QueryIter::new(load_input_out_point, Source::Input).for_each(|out_point| {
-            hasher.update(out_point.as_slice());
-        });
-        // hash all outputs with data
-        QueryIter::new(load_cell, Source::Output)
-            .zip(QueryIter::new(load_cell_data, Source::Output))
-            .for_each(|(cell, data)| {
-                hasher.update(cell.as_slice());
-                hasher.update((data.len() as u32).to_le_bytes().as_ref());
-                hasher.update(data.as_slice());
-            });
-        let mut hash_result = [0u8; 32];
-        hasher.finalize(&mut hash_result);
-        hash_result
+        let tx = load_transaction()?
+            .raw()
+            .as_builder()
+            .cell_deps(Default::default())
+            .build();
+        blake2b_256(tx.as_slice())
     };
 
     let mut pubkey_hash = [0u8; 20];

--- a/tests/src/tests.rs
+++ b/tests/src/tests.rs
@@ -5,8 +5,10 @@ use ckb_std::since::{EpochNumberWithFraction, Since};
 use ckb_testtool::{
     builtin::ALWAYS_SUCCESS,
     ckb_crypto::secp::Generator,
-    ckb_hash::blake2b_256,
-    ckb_types::{bytes::Bytes, core::TransactionBuilder, packed::*, prelude::*},
+    ckb_hash::{blake2b_256, new_blake2b},
+    ckb_types::{
+        bytes::Bytes, core::TransactionBuilder, core::TransactionView, packed::*, prelude::*,
+    },
     context::Context,
 };
 use musig2::{
@@ -95,6 +97,26 @@ fn multisig(
     aggregated_signature_1.to_bytes().to_vec()
 }
 
+/// Compute the message of a transaction
+/// We prefer computing the message this way rather than using the transaction hash.
+/// This ensures the signature remains valid even if the script code is updated.
+fn compute_tx_message(tx: &TransactionView) -> [u8; 32] {
+    let mut hasher = new_blake2b();
+    // all input out points
+    for input in tx.inputs() {
+        hasher.update(input.previous_output().as_slice());
+    }
+    // all outputs with data
+    for (output, data) in tx.outputs_with_data_iter() {
+        hasher.update(output.as_slice());
+        hasher.update((data.len() as u32).to_le_bytes().as_ref());
+        hasher.update(&data);
+    }
+    let mut hash_result = [0u8; 32];
+    hasher.finalize(&mut hash_result);
+    hash_result
+}
+
 #[test]
 fn test_funding_lock() {
     // deploy contract
@@ -159,7 +181,7 @@ fn test_funding_lock() {
         .build();
 
     // sign and add witness
-    let message: [u8; 32] = tx.hash().as_slice().try_into().unwrap();
+    let message: [u8; 32] = compute_tx_message(&tx);
     let signature = multisig(sec_key_1, sec_key_2, key_agg_ctx, message);
 
     let witness = [
@@ -480,7 +502,7 @@ fn test_commitment_lock_with_two_pending_htlcs() {
         .capacity((1000 * BYTE_SHANNONS - payment_amount1 as u64).pack())
         .lock(new_lock_script.clone())
         .build()];
-    let outputs_data = vec![Bytes::new()];
+    let outputs_data = [Bytes::new()];
     let tx = TransactionBuilder::default()
         .cell_deps(cell_deps.clone())
         .inputs(inputs)
@@ -489,7 +511,7 @@ fn test_commitment_lock_with_two_pending_htlcs() {
         .build();
 
     // sign with remote_htlc_pubkey
-    let message: [u8; 32] = tx.hash().as_slice().try_into().unwrap();
+    let message: [u8; 32] = compute_tx_message(&tx);
 
     let signature = remote_htlc_key1
         .0
@@ -558,7 +580,7 @@ fn test_commitment_lock_with_two_pending_htlcs() {
         .capacity((1000 * BYTE_SHANNONS - payment_amount1 as u64).pack())
         .lock(new_lock_script.clone())
         .build()];
-    let outputs_data = vec![Bytes::new()];
+    let outputs_data = [Bytes::new()];
     let tx = TransactionBuilder::default()
         .cell_deps(cell_deps.clone())
         .inputs(inputs)
@@ -567,7 +589,7 @@ fn test_commitment_lock_with_two_pending_htlcs() {
         .build();
 
     // sign with local_htlc_pubkey
-    let message: [u8; 32] = tx.hash().as_slice().try_into().unwrap();
+    let message: [u8; 32] = compute_tx_message(&tx);
 
     let signature = local_htlc_key1
         .0
@@ -605,7 +627,7 @@ fn test_commitment_lock_with_two_pending_htlcs() {
         .build();
 
     // sign with local_htlc_pubkey
-    let message: [u8; 32] = tx.hash().as_slice().try_into().unwrap();
+    let message: [u8; 32] = compute_tx_message(&tx);
 
     let signature = local_htlc_key1
         .0
@@ -656,7 +678,7 @@ fn test_commitment_lock_with_two_pending_htlcs() {
         .capacity((1000 * BYTE_SHANNONS - payment_amount2 as u64).pack())
         .lock(new_lock_script.clone())
         .build()];
-    let outputs_data = vec![Bytes::new()];
+    let outputs_data = [Bytes::new()];
     let tx = TransactionBuilder::default()
         .cell_deps(cell_deps.clone())
         .inputs(inputs)
@@ -665,7 +687,7 @@ fn test_commitment_lock_with_two_pending_htlcs() {
         .build();
 
     // sign with remote_htlc_pubkey
-    let message: [u8; 32] = tx.hash().as_slice().try_into().unwrap();
+    let message: [u8; 32] = compute_tx_message(&tx);
 
     let signature = remote_htlc_key2
         .0
@@ -705,7 +727,7 @@ fn test_commitment_lock_with_two_pending_htlcs() {
         .capacity((1000 * BYTE_SHANNONS - payment_amount2 as u64).pack())
         .lock(new_lock_script.clone())
         .build()];
-    let outputs_data = vec![Bytes::new()];
+    let outputs_data = [Bytes::new()];
     let tx = TransactionBuilder::default()
         .cell_deps(cell_deps)
         .inputs(inputs)
@@ -714,7 +736,7 @@ fn test_commitment_lock_with_two_pending_htlcs() {
         .build();
 
     // sign with local_htlc_pubkey
-    let message: [u8; 32] = tx.hash().as_slice().try_into().unwrap();
+    let message: [u8; 32] = compute_tx_message(&tx);
 
     let signature = local_htlc_key2
         .0
@@ -931,7 +953,7 @@ fn test_commitment_lock_with_two_pending_htlcs_and_sudt() {
         .build();
 
     // sign with remote_htlc_pubkey
-    let message: [u8; 32] = tx.hash().as_slice().try_into().unwrap();
+    let message: [u8; 32] = compute_tx_message(&tx);
 
     let signature = remote_htlc_key1
         .0
@@ -981,7 +1003,7 @@ fn test_commitment_lock_with_two_pending_htlcs_and_sudt() {
         .build();
 
     // sign with local_htlc_pubkey
-    let message: [u8; 32] = tx.hash().as_slice().try_into().unwrap();
+    let message: [u8; 32] = compute_tx_message(&tx);
 
     let signature = local_htlc_key1
         .0
@@ -1047,7 +1069,7 @@ fn test_commitment_lock_with_two_pending_htlcs_and_sudt() {
         .build();
 
     // sign with remote_htlc_pubkey
-    let message: [u8; 32] = tx.hash().as_slice().try_into().unwrap();
+    let message: [u8; 32] = compute_tx_message(&tx);
 
     let signature = remote_htlc_key2
         .0
@@ -1100,7 +1122,7 @@ fn test_commitment_lock_with_two_pending_htlcs_and_sudt() {
         .build();
 
     // sign with local_htlc_pubkey
-    let message: [u8; 32] = tx.hash().as_slice().try_into().unwrap();
+    let message: [u8; 32] = compute_tx_message(&tx);
 
     let signature = local_htlc_key2
         .0


### PR DESCRIPTION
This PR update the signing message of funding lock and commitment lock(with pending htlc).

In the original code, the signing message was tx_hash. This approach faces challenges during script upgrades because the cell_dep field in the transaction became invalid, which causes the entire transaction invalid.

To resolve this, we empty `RawTransaction#cell_dep` field, then use `blake2b_256(&raw_tx.as_slice())` to get the signing message.